### PR TITLE
Fix parsing empty list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'streamlit>=1,<2'
+    'streamlit>=1.11,<2'
 ]
 
 tests_require = ['pytest', 'tox']

--- a/streamlit_parameters/demos/parameters.py
+++ b/streamlit_parameters/demos/parameters.py
@@ -18,7 +18,7 @@ import sys
 import typing
 
 import streamlit
-import streamlit.cli
+import streamlit.web.cli
 
 import streamlit_parameters
 
@@ -240,4 +240,4 @@ if __name__ == "__main__":
 def console_main():
     filename = __file__
     sys.argv = ["streamlit", "run", filename]
-    streamlit.cli.main()
+    streamlit.web.cli.main()

--- a/streamlit_parameters/parameters.py
+++ b/streamlit_parameters/parameters.py
@@ -246,16 +246,17 @@ class Parameters(object):
             raw_str = raw_str[1:]
         if raw_str[-1] in (")", "]"):
             raw_str = raw_str[:-1]
-        values = raw_str.split(split_sequence)
-        # Remove any quotes that may be added to the string.
         new_values = []
-        for value in values:
-            new_value = value.strip()
-            if new_value[0] == "'":
-                new_value = new_value[1:]
-            if new_value[-1] == "'":
-                new_value = new_value[:-1]
-            new_values.append(new_value)
+        if raw_str:
+            values = raw_str.split(split_sequence)
+            # Remove any quotes that may be added to the string.
+            for value in values:
+                new_value = value.strip()
+                if new_value[0] == "'":
+                    new_value = new_value[1:]
+                if new_value[-1] == "'":
+                    new_value = new_value[:-1]
+                new_values.append(new_value)
         return new_values
 
     @staticmethod

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -17,4 +17,4 @@ import streamlit_parameters
 
 def test_gday():
     print("Test - Gday")
-    assert("G'day!" == streamlit_parameters.hello.gday())
+    assert "G'day!" == streamlit_parameters.hello.gday()

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = py36, py38, flake8
 
 [testenv]
 deps =
-    pytest
+    .[test]
 commands =
     pytest
 


### PR DESCRIPTION
When clearing an `st.multiselect`, the query parameter is set to an empty list `[]`. Initially, there is no error thrown because the program is using session state. However, if you were to refresh the page with an empty list `[]` parameter, an error is thrown:

```
IndexError: string index out of range
Traceback:
<OMMITTED>
File "/home/ubuntu/.local/lib/python3.8/site-packages/streamlit_parameters/parameters.py", line 363, in register_string_list_parameter
    values = Parameters._read_list_or_tuple(key)
File "/home/ubuntu/.local/lib/python3.8/site-packages/streamlit_parameters/parameters.py", line 254, in _read_list_or_tuple
    if new_value[0] == "'":
```

